### PR TITLE
Add additional config params for Cow helpers

### DIFF
--- a/d2bs/kolbot/libs/bots/Cows.js
+++ b/d2bs/kolbot/libs/bots/Cows.js
@@ -222,13 +222,29 @@ function Cows() {
 	Town.goToTown(1);
 	Town.doChores();
 
-	leg = this.getLeg();
-	tome = this.getTome();
 
-	this.openPortal(leg, tome);
+	if (!Config.Cows.PublicGame || Config.Cows.PublicGame && Config.Cows.CowLeader || Misc.getPlayerCount() <= 1) {
+		print("Getting leg");
+		try {
+			leg = this.getLeg();
+			tome = this.getTome();
+			this.openPortal(leg, tome);
+		}
+		catch(err) {
+			print(err);
+			Town.goToTown(1);
+		}
+	} else {
+		Town.goToTown(1);
+		Town.move("portalspot");
+		print("Waiting for portal...");
+		delay(Config.Cows.WaitForParty || 10000);
+	}
+
 	Pather.usePortal(39);
 	Precast.doPrecast(false);
 	this.clearCowLevel();
 
 	return true;
 }
+

--- a/d2bs/kolbot/libs/common/Config.js
+++ b/d2bs/kolbot/libs/common/Config.js
@@ -388,6 +388,12 @@ var Config = {
 	Countess: {
 		KillGhosts: false
 	},
+	Cows: {
+		PublicGame: false,
+		PortalRetry: 3,
+		CowLeader: false,
+		WaitForParty: 3000,
+	},
 	Baal: {
 		DollQuit: false,
 		SoulQuit: false,


### PR DESCRIPTION
This allows a bot to join public games and enter Cow portals they didn't create, or multiple bots can create a game and do cows together.
Available Params:
```
Config.Cows.PublicGame = true|false;  // Should the bot look for an existing portal`
Config.Cows.CowLeader = true|false;  // Even if PublicGame is true, get the leg and create portal anyway
Config.Cows.WaitForParty = <milliseconds int>;  // Joiner will wait for portal for x milliseconds before trying to enter the portal
```